### PR TITLE
lnnode: working image

### DIFF
--- a/builders/play/btcnode/btcnode.v
+++ b/builders/play/btcnode/btcnode.v
@@ -58,7 +58,7 @@ pub fn build(args docker.BuildArgs) ! {
 	r.add_sshserver()!
 
 	// runtime dependencies
-	r.add_package(name: "fuse, libstdc++, libgomp, libstdc++-dev, musl-dev")!
+	r.add_package(name: "fuse, libstdc++, libgomp, libstdc++-dev, musl-dev, jq")!
 
 	// init script to download bitcoin snapshot
 	r.add_zinit_cmd(
@@ -76,7 +76,8 @@ pub fn build(args docker.BuildArgs) ! {
 			mkdir -p /mnt/workdir
 
 			if [ ! -f /mnt/bitcoin-snapshot.flist ]; then
-				wget https://btc.grid.tf/snapshots/bitcoin-snapshot-2024-04-07.flist -O /mnt/bitcoin-snapshot.flist
+				wget -O- https://btc.grid.tf/api/flist/snapshots/bitcoin-snapshot-latest.flist/light | jq -r .target > /mnt/snapshot-link
+				wget https://btc.grid.tf/snapshots/bitcoin-snapshot-latest.flist -O /mnt/bitcoin-snapshot.flist
 			fi
 		"
 	)!
@@ -117,7 +118,7 @@ pub fn build(args docker.BuildArgs) ! {
 				BTCUSER=user
 			fi
 
-			bitcoind -rpcbind=:: -rpcallowip=200::/7 -rpcpassword=\$BTCPWD -rpcuser=\$BTCUSER
+			bitcoind -rpcbind=:: -rpcallowip=200::/7 -rpcpassword=\$BTCPWD -rpcuser=\$BTCUSER -zmqpubhashtx=tcp://[::]:28332 -zmqpubhashblock=tcp://[::]:28333 -zmqpubrawblock=tcp://[::]:28332 -zmqpubrawtx=tcp://[::]:28333
 		"
 	)!
 

--- a/builders/play/lnnode/README.md
+++ b/builders/play/lnnode/README.md
@@ -10,10 +10,23 @@ node.
 Here are the steps the image does on boot (runtime):
 
 1. `lnd-setup`
-4. `lnd`
-    - Run the actual `lnd` daemon. The daemon will only accept connection via **Planetary Network**.
-    - The password will be taken from environment variable (`BTCPWD`) or the default one (`defaultbtc`) will be used.
-    - The user will be taken from environment variable (`BTCUSER`) or the default one (`user`) will be used.
+  - Check variable environment
+  - Create a wallet if it doesn't exists
+  - Prepare system environement
+2. `lnd`
+  - Run the actual `lnd` daemon. The daemon will only accept connection via **Planetary Network**.
+  - The password will be taken from environment variable (`BTCPWD`) or the default one (`defaultbtc`) will be used.
+  - The user will be taken from environment variable (`BTCUSER`) or the default one (`user`) will be used.
+
+The location `/safe` contains seed and password. You should mount a disk in order to make this location persistant.
+Otherwise you have to login into the machine and keep this directory safe somewhere. You can run the node without
+a disk mounted, this won't be treated as an issue.
+
+Wallet is automatically created based on password and seed, on runtime.
+
+Note: it seems that `lnd` have some issue parsing IPv6 for some command line arguments, in order to make things
+working and easier to maintain, a fake domain `bitcoind.local` is added into `/etc/hosts` pointing to the bitcoind
+node passed as environment variable.
 
 ## How to build it
 
@@ -74,6 +87,7 @@ And now:
 
 You can query your lnnode node remotely via:
 ```sh
+FIXME
 ```
 
 That's it !

--- a/builders/play/lnnode/README.md
+++ b/builders/play/lnnode/README.md
@@ -1,4 +1,79 @@
-# Bitcoin Lightning Node image builder
+# Lightning Network node image builder
 
 ## Build process
 
+This builder script create a final image which can boot a lightning network daemon connecting an existing bitcoind
+node.
+
+## Runtime
+
+Here are the steps the image does on boot (runtime):
+
+1. `lnd-setup`
+4. `lnd`
+    - Run the actual `lnd` daemon. The daemon will only accept connection via **Planetary Network**.
+    - The password will be taken from environment variable (`BTCPWD`) or the default one (`defaultbtc`) will be used.
+    - The user will be taken from environment variable (`BTCUSER`) or the default one (`user`) will be used.
+
+## How to build it
+
+When using the default installer for the builder, you can just trigger the build like this:
+```sh
+v -cg run /root/code/github/threefoldtech/builders/examples/lnnode/play_lnnode.v
+```
+
+## How to upload it to the hub
+
+When the image is ready, you can simply take it and export to upload it to the grid hub.
+
+Run a temporarily container with the newly built image. We override the entrypoint to avoid starting the bitcoin node.
+```sh
+docker run --rm -dit --entrypoint /bin/bash --name lnnode-export lnnode
+```
+
+You can now extract the filesystem content:
+```sh
+docker export lnnode-export > lnnode.tar
+docker stop lnnode-export
+```
+
+The `stop` will take care to cleanup the docker, because flag `--rm` were supplied.
+
+Now we have the root filesystem ready locally. Let's compress it:
+```sh
+gzip lnnode.tar
+```
+
+You can now get that `lnnode.tar.gz` file (via scp, whatever) and upload it directly as it to the `hub.grid.tf`.
+
+## How to run the VM
+
+In order to run that Micro VM easily, just go to a grid playground (eg: `play.test.grid.tf`).
+
+1. Create a new Micro VM
+2. In VM Image, select `Other`
+3. FList URL: `https://hub.grid.tf/maxux42.3bot/lnnode.flist` (will be changed later)
+4. Entry Point:
+    - Keep the default one: `/sbin/zinit init`
+5. Enable **public IPv6** and **Planetary Network**
+6. In Environment Variables:
+    - Add a new `BTCHOST` variable with your bitcoind host IPv6 address
+    - Add a new `BTCUSER` variable with your bitcoind user set (empty will use default from btcnode)
+    - Add a new `BTCPWD` variable with your bitcoind password set (empty will use default from btcnode)
+7. Keep your `SSH_KEY` set in order to manage your machine
+8. Add a Disk to persist your important data:
+    - Size: at least `1G`
+    - Mount Point: `/safe` (this is important, just `/safe`)
+
+**Deploy the machine !**
+
+And now:
+- You can SSH the Micro VM to check the status.
+- You can use command `zinit` to see daemon status
+- In case of a well known error, a file called `/errors` will contains more information, you can check that file
+
+You can query your lnnode node remotely via:
+```sh
+```
+
+That's it !

--- a/builders/play/lnnode/README.md
+++ b/builders/play/lnnode/README.md
@@ -1,0 +1,4 @@
+# Bitcoin Lightning Node image builder
+
+## Build process
+

--- a/builders/play/lnnode/lnd-default.conf
+++ b/builders/play/lnnode/lnd-default.conf
@@ -1,5 +1,5 @@
 [Application Options]
-wallet-unlock-password-file=/tmp/password
+wallet-unlock-password-file=/safe/password
 
 [Bitcoin]
 bitcoin.active=true

--- a/builders/play/lnnode/lnd-default.conf
+++ b/builders/play/lnnode/lnd-default.conf
@@ -1,0 +1,18 @@
+[Application Options]
+wallet-unlock-password-file=/tmp/password
+
+[Bitcoin]
+bitcoin.active=true
+bitcoin.mainnet=true
+bitcoin.node=bitcoind
+
+[Bitcoind]
+
+bitcoind.rpchost=bitcoind.local:8332
+; bitcoind.rpcuser=user
+; bitcoind.rpcpass=defaultbtc
+
+bitcoind.zmqpubrawblock=tcp://bitcoind.local:28332
+bitcoind.zmqpubrawtx=tcp://bitcoind.local:28333
+bitcoind.zmqreaddeadline=10s
+

--- a/builders/play/lnnode/lnnode.v
+++ b/builders/play/lnnode/lnnode.v
@@ -17,6 +17,7 @@ pub fn build(args docker.BuildArgs) ! {
 	r.add_from(image: 'gobuilder', alias: 'builder')!
 
 	r.add_codeget(url: 'https://github.com/lightningnetwork/lnd', dest: "/code/lnd")!
+	r.add_codeget(url: 'https://github.com/lightninglabs/lndinit', dest: "/code/lndinit")!
 	r.add_package(name: "bash, bison, build-base, curl, linux-headers, make, pkgconf, python3, xz, autoconf, automake, libtool")!
 
 	// building bitcoin required for musl on alpine
@@ -27,14 +28,24 @@ pub fn build(args docker.BuildArgs) ! {
 	"
 	)!
 
+	r.add_run(
+		cmd: "
+			cd /code/lndinit
+			make
+	"
+	)!
+
+
 	// download sample config file from repository
-	// configurl := "https://raw.githubusercontent.com/threefoldtech/builders/development/builders/play/btcnode/bitcoin-source.conf"
-	// r.add_run(cmd: "wget $configurl -O /root/bitcoin-source.conf")!
+	configurl := "https://raw.githubusercontent.com/threefoldtech/builders/development-lnnode/builders/play/lnnode/lnd-default.conf"
+	r.add_run(cmd: "wget $configurl -O /root/lnd-source.conf")!
 
 	r.add_from(image: 'base', alias: 'installer')!
 	
+	r.add_copy(from: "builder", source: "/root/lnd-source.conf", dest: "/root/lnd-source.conf")!
 	r.add_copy(from: "builder", source: "/app/bin/lnd", dest: "/bin/lnd")!
 	r.add_copy(from: "builder", source: "/app/bin/lncli", dest: "/bin/lncli")!
+	r.add_copy(from: "builder", source: "/code/lndinit/lndinit-debug", dest: "/bin/lndinit")!
 
 	r.add_sshserver()!
 
@@ -42,10 +53,58 @@ pub fn build(args docker.BuildArgs) ! {
 	r.add_package(name: "fuse, libstdc++, libgomp, libstdc++-dev, musl-dev, jq")!
 
 	r.add_zinit_cmd(
-		name: "lnd",
-		// after: "bitcoind-setup",
+		name: "lnd-setup",
+		oneshot: true,
 		exec: "
-			echo HELLO WORLD > /hello
+			if [ -z \$BTCHOST ]; then
+			    echo 'Missing BTCHOST' >> /errors
+				exit 1
+			fi
+
+			if ! grep -q bitcoind.local /etc/hosts; then
+				echo >> /etc/hosts
+				echo \$BTCHOST    bitcoind.local >> /etc/hosts
+			fi
+
+			mkdir -p /root/.lnd
+			cp /root/lnd-source.conf /root/.lnd/lnd.conf
+
+			mkdir -p /safe
+
+			if [[ ! -f /safe/seed ]]; then
+				echo Creating seed
+    			lndinit gen-seed > /safe/seed
+			fi
+
+			if [[ ! -f /safe/password ]]; then
+				echo Creating password
+				lndinit gen-password > /safe/password
+			fi
+	
+			echo Creating wallet
+			lndinit -v init-wallet --secret-source=file --file.seed=/safe/seed --file.wallet-password=/safe/password --init-file.output-wallet-dir=/root/.lnd/data/chain/bitcoin/mainnet --init-file.validate-password
+		"
+	)!
+
+
+	r.add_zinit_cmd(
+		name: "lnd",
+		after: "lnd-setup",
+		exec: "
+			if [ -z \$BTCHOST ]; then
+			    echo 'Missing BTCHOST' >> /errors
+				exit 1
+			fi
+
+			if [ -z \$BTCUSER ]; then 
+				BTCUSER=user
+			fi
+
+			if [ -z \$BTCPWD ]; then
+				BTCPWD=defaultbtc
+			fi
+
+			lnd --bitcoind.rpcuser=\$BTCUSER --bitcoind.rpcpass=\$BTCPWD --wallet-unlock-allow-create
 		"
 	)!
 

--- a/builders/play/lnnode/lnnode.v
+++ b/builders/play/lnnode/lnnode.v
@@ -37,7 +37,7 @@ pub fn build(args docker.BuildArgs) ! {
 
 
 	// download sample config file from repository
-	configurl := "https://raw.githubusercontent.com/threefoldtech/builders/development-lnnode/builders/play/lnnode/lnd-default.conf"
+	configurl := "https://raw.githubusercontent.com/threefoldtech/builders/development/builders/play/lnnode/lnd-default.conf"
 	r.add_run(cmd: "wget $configurl -O /root/lnd-source.conf")!
 
 	r.add_from(image: 'base', alias: 'installer')!

--- a/builders/play/lnnode/lnnode.v
+++ b/builders/play/lnnode/lnnode.v
@@ -1,0 +1,53 @@
+module lnnode
+
+import freeflowuniverse.crystallib.docker
+import threefoldtech.builders.core.base
+import threefoldtech.builders.core.gobuilder
+
+pub fn build(args docker.BuildArgs) ! {
+	mut engine := args.engine
+
+	// make sure dependency has been build
+	gobuilder.build(engine: engine, reset: args.reset, strict: args.strict)!
+
+	// specify we want to build an alpine version
+	mut r := engine.recipe_new(name: 'lnnode', platform: .alpine)
+
+	// starting from light base image
+	r.add_from(image: 'gobuilder', alias: 'builder')!
+
+	r.add_codeget(url: 'https://github.com/lightningnetwork/lnd', dest: "/code/lnd")!
+	r.add_package(name: "bash, bison, build-base, curl, linux-headers, make, pkgconf, python3, xz, autoconf, automake, libtool")!
+
+	// building bitcoin required for musl on alpine
+	r.add_run(
+		cmd: "
+			cd /code/lnd
+			make install
+	"
+	)!
+
+	// download sample config file from repository
+	// configurl := "https://raw.githubusercontent.com/threefoldtech/builders/development/builders/play/btcnode/bitcoin-source.conf"
+	// r.add_run(cmd: "wget $configurl -O /root/bitcoin-source.conf")!
+
+	r.add_from(image: 'base', alias: 'installer')!
+	
+	r.add_copy(from: "builder", source: "/app/bin/lnd", dest: "/bin/lnd")!
+	r.add_copy(from: "builder", source: "/app/bin/lncli", dest: "/bin/lncli")!
+
+	r.add_sshserver()!
+
+	// runtime dependencies
+	r.add_package(name: "fuse, libstdc++, libgomp, libstdc++-dev, musl-dev, jq")!
+
+	r.add_zinit_cmd(
+		name: "lnd",
+		// after: "bitcoind-setup",
+		exec: "
+			echo HELLO WORLD > /hello
+		"
+	)!
+
+	r.build(args.reset)!
+}

--- a/examples/lnnode/play_lnnode.v
+++ b/examples/lnnode/play_lnnode.v
@@ -1,0 +1,35 @@
+module main
+
+import freeflowuniverse.crystallib.docker
+import threefoldtech.builders.play.lnnode
+
+// copy from goca example
+
+fn do() ! {
+	dockerregistry_datapath:=""
+	// dockerregistry_datapath:="/Volumes/FAST/DOCKERHUB"
+	// prefix:="despiegk/" //dont forget trailing slash
+	prefix:=""
+	reset:=true
+	localonly:=false
+
+	mut engine := docker.new(prefix:prefix,localonly:localonly)!
+
+	if dockerregistry_datapath.len>0{
+		engine.registry_add(datapath:dockerregistry_datapath)! //this means we run one locally
+	}
+	
+	if reset{
+		//TODO: prob better to only remove what is relevant to building
+		engine.reset_all()!
+	}
+
+	
+	lnnode.build(engine:&engine,reset:false)!
+
+}
+
+fn main() {
+
+	do() or { panic(err) }
+}


### PR DESCRIPTION
- Unattended init with `seed` and `password`
- Use builder like `btcnode`
- Update `btcnode` to support incoming connection from `lnd`
- Support `btchost` to be set via environment variable
- Support `IPv6`
- Boot in less than 1 min, connected to a remote `btcnode`
- Readme updated to reflect how to use it and some implementation details